### PR TITLE
modify a local-login strategy to print out an error message

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -71,11 +71,13 @@ passport.use(
 			}
 			if (!rowCount) {
 				return done(null, false, { message: 'There is no account with this email.' });
-			}
-			if (!(password == row[0][2].value)) {
+			} else if (!row[0][2].value) {
+				return done(null, false, { message: "Try 'login with Google'" });
+			} else if (!(password == row[0][2].value)) {
 				return done(null, false, { message: 'Incorrect Password.' });
+			} else {
+				return done(null, row[0][0].value);
 			}
-			return done(null, row[0][0].value);
 		});
 		db.execSql(loginRequest);
 	}


### PR DESCRIPTION
modify a local-login strategy to print out an error message
when users who registered through google try to login locally